### PR TITLE
Fix: Add checks for undefined properties in streamGPTReply function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -196,19 +196,22 @@ ipcMain.handle("LiteLoader.gpt_reply.streamGPTReply", async (event, params) => {
 
         let chunkIdx = 0;
         for await (const chunk of completion) {
-            const chunkContent = chunk.choices[0].delta ? chunk.choices[0].delta.content || "" : "";
-            event.sender.send(
-                "LiteLoader.gpt_reply.streamData",
-                chunkContent,
-                chunkIdx
-            );
-            chunkIdx++;
+            const chunkContent = chunk?.choices?.[0]?.delta?.content ?? '';
+            if (chunkContent) {
+                event.sender.send(
+                    "LiteLoader.gpt_reply.streamData",
+                    chunkContent,
+                    chunkIdx
+                );
+                chunkIdx++;
+            }
         }
     } catch (error) {
         log(error);
         event.sender.send("LiteLoader.gpt_reply.streamError", error.message);
     }
 });
+
 
 /**
  * 创建窗口时的触发事件


### PR DESCRIPTION
尝试解决了在 `streamGPTReply` 函数中由于未正确检查 `chunk.choices[0].delta` 是否为 `undefined` 而导致的错误：

"Error: Cannot read properties of undefined (reading 'delta')"

添加了对 `chunk.choices`、`chunk.choices[0]` 和 `choice.delta` 的存在性检查，确保在访问属性之前验证对象是否存在。

该修复可以防止在处理 OpenAI 流式响应时出现未捕获的异常。

Fixes #16 