### PR TITLE
feat: 添加对duckduckgo api的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+pnpm-lock.yaml
+yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "duckduckgo-ai-chat-cjs": "^1.0.2",
     "openai": "^4.45.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -224,15 +224,13 @@ ipcMain.handle("LiteLoader.gpt_reply.getGPTReply", async (event, params) => {
 ipcMain.handle("LiteLoader.gpt_reply.streamGPTReply", async (event, params) => {
     try {
         const { system_message, prompt, model } = params;
-        let finalprompt;
         let stream;
         let streamIdx = 0;
         switch (model) {
             case "4ominiddg":
                 duckai = await initChat("gpt-4o-mini")
-                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
-                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
-                stream = await duckai.fetchStream(finalprompt);
+                stream = await duckai.fetchStream("prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题。你回复的所有内容都要有关于问题，而不要对prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt);
                 streamIdx = 0;
                 for await (const data of stream) {
                     const dataContent = data ?? "";
@@ -248,9 +246,8 @@ ipcMain.handle("LiteLoader.gpt_reply.streamGPTReply", async (event, params) => {
                 break;
             case "llamaddg":
                 duckai = await initChat("llama")
-                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
-                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
-                stream = await duckai.fetchStream(finalprompt);
+                stream = await duckai.fetchStream("prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题。你回复的所有内容都要有关于问题，而不要对prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt);
                 streamIdx = 0;
                 for await (const data of stream) {
                     const dataContent = data ?? "";
@@ -266,9 +263,8 @@ ipcMain.handle("LiteLoader.gpt_reply.streamGPTReply", async (event, params) => {
                 break;
             case "mixtralddg":
                 duckai = await initChat("mixtral")
-                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
-                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
-                stream = await duckai.fetchStream(finalprompt);
+                stream = await duckai.fetchStream("prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题。你回复的所有内容都要有关于问题，而不要对prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt);
                 streamIdx = 0;
                 for await (const data of stream) {
                     const dataContent = data ?? "";
@@ -284,9 +280,8 @@ ipcMain.handle("LiteLoader.gpt_reply.streamGPTReply", async (event, params) => {
                 break;
             case "claudeddg":
                 duckai = await initChat("claude-3-haiku")
-                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
-                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
-                stream = await duckai.fetchStream(finalprompt);
+                stream = await duckai.fetchStream("prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题。你回复的所有内容都要有关于问题，而不要对prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt);
                 streamIdx = 0;
                 for await (const data of stream) {
                     const dataContent = data ?? "";

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,9 @@ const fs = require("fs");
 const path = require("path");
 const { BrowserWindow, ipcMain, shell } = require("electron");
 const OpenAI = require("openai");
-
+const { initChat } = require("duckduckgo-ai-chat-cjs")
 let openai = null;
+let duckai = null;
 
 const pluginDataPath = LiteLoader.plugins["gpt_reply"].path.data;
 const settingsPath = path.join(pluginDataPath, "settings.json");
@@ -40,9 +41,20 @@ try {
         apiKey: apiKey,
         baseURL: baseURL,
     });
+    // duckai = initChat("gpt-4o-mini");
 } catch (error) {
     openai = null;
 }
+
+// async function initializeDuckAI() {
+//     try {
+//         duckai = await initChat("mixtral");
+//         console.log("duckai initialized");
+//     } catch (error) {
+//         duckai = null;
+//     }
+// }
+// initializeDuckAI();
 
 /**
  * 使用默认值更新现有设置对象中的缺失键。
@@ -101,7 +113,7 @@ ipcMain.on(
 );
 
 ipcMain.handle("LiteLoader.gpt_reply.checkOpenAI", (event, message) => {
-    return openai ? true : false;
+    return (openai || duckai) ? true : false;
 });
 
 /**
@@ -162,15 +174,42 @@ ipcMain.handle("LiteLoader.gpt_reply.logToMain", (event, ...args) => {
 ipcMain.handle("LiteLoader.gpt_reply.getGPTReply", async (event, params) => {
     try {
         const { system_message, prompt, model } = params;
-        const completion = await openai.chat.completions.create({
-            messages: [
-                { role: "system", content: system_message },
-                { role: "user", content: prompt },
-            ],
-            model: model,
-        });
+        let response;
 
-        const response = completion.choices[0].message.content;
+        switch (model) {
+            case "4ominiddg":
+                // 处理 duckduckgo 模型的情况
+                duckai = await initChat("gpt-4o-mini")
+                response = await duckai.fetchFull(system_message);
+                break;
+            case "llamaddg":
+                // 处理 duckduckgo 模型的情况
+                duckai = await initChat("llama")
+                response = await duckai.fetchFull(system_message);
+                break;
+            case "mixtralddg":
+                // 处理 duckduckgo 模型的情况
+                duckai = await initChat("mixtral")
+                response = await duckai.fetchFull(system_message);
+                break;
+            case "claudeddg":
+                // 处理 duckduckgo 模型的情况
+                duckai = await initChat("claude-3-haiku")
+                response = await duckai.fetchFull(system_message);
+                break;
+            default:
+                // 处理默认情况
+                const completion = await openai.chat.completions.create({
+                    messages: [
+                        { role: "system", content: system_message },
+                        { role: "user", content: prompt },
+                    ],
+                    model: model,
+                });
+                response = completion.choices[0].message.content;
+                break;
+        }
+
         return response;
     } catch (error) {
         log(error);
@@ -185,26 +224,105 @@ ipcMain.handle("LiteLoader.gpt_reply.getGPTReply", async (event, params) => {
 ipcMain.handle("LiteLoader.gpt_reply.streamGPTReply", async (event, params) => {
     try {
         const { system_message, prompt, model } = params;
-        const completion = await openai.chat.completions.create({
-            messages: [
-                { role: "system", content: system_message },
-                { role: "user", content: prompt },
-            ],
-            model: model,
-            stream: true,
-        });
+        let finalprompt;
+        let stream;
+        let streamIdx = 0;
+        switch (model) {
+            case "4ominiddg":
+                duckai = await initChat("gpt-4o-mini")
+                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
+                stream = await duckai.fetchStream(finalprompt);
+                streamIdx = 0;
+                for await (const data of stream) {
+                    const dataContent = data ?? "";
+                    if (dataContent) {
+                        event.sender.send(
+                            "LiteLoader.gpt_reply.streamData",
+                            dataContent,
+                            streamIdx
+                        );
+                        streamIdx++;
+                    }
+                }
+                break;
+            case "llamaddg":
+                duckai = await initChat("llama")
+                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
+                stream = await duckai.fetchStream(finalprompt);
+                streamIdx = 0;
+                for await (const data of stream) {
+                    const dataContent = data ?? "";
+                    if (dataContent) {
+                        event.sender.send(
+                            "LiteLoader.gpt_reply.streamData",
+                            dataContent,
+                            streamIdx
+                        );
+                        streamIdx++;
+                    }
+                }
+                break;
+            case "mixtralddg":
+                duckai = await initChat("mixtral")
+                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
+                stream = await duckai.fetchStream(finalprompt);
+                streamIdx = 0;
+                for await (const data of stream) {
+                    const dataContent = data ?? "";
+                    if (dataContent) {
+                        event.sender.send(
+                            "LiteLoader.gpt_reply.streamData",
+                            dataContent,
+                            streamIdx
+                        );
+                        streamIdx++;
+                    }
+                }
+                break;
+            case "claudeddg":
+                duckai = await initChat("claude-3-haiku")
+                finalprompt = "prompt: 你是一个聊天机器人，这是当前使用你的人设置的系统提示词，" + system_message
+                    + "\n" + "接下来是你要回答的问题，请使用中文回复。你回复的所有内容都要有关于问题，而不要将prompt部分中存在的内容进行回答" + "\n" + "questions: " + prompt;
+                stream = await duckai.fetchStream(finalprompt);
+                streamIdx = 0;
+                for await (const data of stream) {
+                    const dataContent = data ?? "";
+                    if (dataContent) {
+                        event.sender.send(
+                            "LiteLoader.gpt_reply.streamData",
+                            dataContent,
+                            streamIdx
+                        );
+                        streamIdx++;
+                    }
+                }
+                break;
+            default:
+                const completion = await openai.chat.completions.create({
+                    messages: [
+                        { role: "system", content: system_message },
+                        { role: "user", content: prompt },
+                    ],
+                    model: model,
+                    stream: true,
+                });
 
-        let chunkIdx = 0;
-        for await (const chunk of completion) {
-            const chunkContent = chunk?.choices?.[0]?.delta?.content ?? '';
-            if (chunkContent) {
-                event.sender.send(
-                    "LiteLoader.gpt_reply.streamData",
-                    chunkContent,
-                    chunkIdx
-                );
-                chunkIdx++;
-            }
+                let chunkIdx = 0;
+                for await (const chunk of completion) {
+                    const chunkContent = chunk?.choices?.[0]?.delta?.content ?? "";
+                    if (chunkContent) {
+                        event.sender.send(
+                            "LiteLoader.gpt_reply.streamData",
+                            chunkContent,
+                            chunkIdx
+                        );
+                        chunkIdx++;
+                    }
+                }
+                break;
         }
     } catch (error) {
         log(error);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -396,7 +396,11 @@ export const onSettingWindowCreated = async (view) => {
                 radio.value === settings.model ||
                 (radio.value === "custom" &&
                     settings.model !== "gpt-4o-mini" &&
-                    settings.model !== "gpt-4o")
+                    settings.model !== "gpt-4o" && 
+                    settings.model !== "4ominiddg" &&
+                    settings.model !== "llamaddg" &&
+                    settings.model !== "mixtralddg" &&
+                    settings.model !== "claudeddg")
             ) {
                 radio.checked = true;
             } else {

--- a/src/settings.html
+++ b/src/settings.html
@@ -178,9 +178,8 @@
               href="javascript:void(0);"
               onclick="gpt_reply.openWeb(`https://platform.openai.com/docs/models/models`)"
               >模型列表</a
-            ><br />duckduckgo暂不支持prompt
+            >
           </setting-text>
-
           <div class="radio-group">
             <label>
               <input
@@ -196,22 +195,6 @@
               GPT-4o
             </label>
             <label>
-              <input type="radio" name="chat-model" value="4ominiddg" />
-              4o-mini-ddg
-            </label>
-            <label>
-              <input type="radio" name="chat-model" value="llamaddg" />
-              llama3.1-ddg
-            </label>
-            <label>
-              <input type="radio" name="chat-model" value="mixtralddg" />
-              mixtral-ddg
-            </label>
-            <label>
-              <input type="radio" name="chat-model" value="claudeddg" />
-              claude-haiku-ddg
-            </label>
-            <label>
               <input type="radio" name="chat-model" value="custom" />
               自定义
               <input
@@ -220,6 +203,34 @@
                 spellcheck="false"
                 placeholder="输入模型号"
               />
+            </label>
+          </div>
+          <setting-text>DuckDuckGo</setting-text>
+          <setting-text
+            data-type="secondary"
+            style="-webkit-line-clamp: initial"
+            >使用 <a
+            href="javascript:void(0);"
+            onclick="gpt_reply.openWeb(`https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1`)"
+            >Duckduckgo AI Chat</a
+          >，是免费的
+          </setting-text>
+          <div class="radio-group">
+            <label>
+              <input type="radio" name="chat-model" value="4ominiddg" />
+              GPT-4o mini
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="claudeddg" />
+              Claude 3 Haiku
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="llamaddg" />
+              Llama 3.1 70B
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="mixtralddg" />
+              Mixtral 8x7B
             </label>
           </div>
         </div>
@@ -330,7 +341,7 @@
           >
         </div>
         <setting-button data-type="secondary" id="settings-github-link"
-          >进去瞅瞅</setting-button
+          >可以进来给个星星吗</setting-button
         >
       </setting-item>
     </setting-list>

--- a/src/settings.html
+++ b/src/settings.html
@@ -1,222 +1,231 @@
 <!-- 设置界面 -->
 <style>
-    .gpt_reply a {
-        color: var(--text-link);
-    }
+  .gpt_reply a {
+    color: var(--text-link);
+  }
 
+  .gpt_reply input {
+    align-self: normal;
+    flex: 1;
+    border-radius: 4px;
+    margin-right: 12px;
+    transition: all 100ms ease-out;
+  }
+
+  .gpt_reply input:focus {
+    padding-left: 4px;
+    background-color: var(--overlay_active);
+  }
+
+  .gpt_reply .input-group {
+    display: flex;
+    flex-direction: row;
+    margin-top: 8px;
+  }
+
+  .gpt_reply .ops-btns > *:not(:last-child) {
+    margin-right: 4px;
+  }
+
+  .gpt_reply setting-item > div {
+    width: 100%;
+  }
+
+  .gpt_reply setting-item > div.width-80 {
+    width: 80% !important;
+  }
+
+  /* Light mode */
+  @media (prefers-color-scheme: light) {
     .gpt_reply input {
-        align-self: normal;
-        flex: 1;
-        border-radius: 4px;
-        margin-right: 12px;
-        transition: all 100ms ease-out;
+      color: black;
     }
+    textarea {
+      color: black;
+    }
+  }
 
-    .gpt_reply input:focus {
-        padding-left: 4px;
-        background-color: var(--overlay_active);
+  /* Dark mode */
+  @media (prefers-color-scheme: dark) {
+    .gpt_reply input {
+      color: white;
     }
+    textarea {
+      color: white;
+    }
+  }
 
-    .gpt_reply .input-group {
-        display: flex;
-        flex-direction: row;
-        margin-top: 8px;
-    }
+  .radio-group {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    align-items: center;
+  }
 
-    .gpt_reply .ops-btns > *:not(:last-child) {
-        margin-right: 4px;
-    }
+  .radio-group label {
+    margin-right: 15px;
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+  }
 
-    .gpt_reply setting-item > div {
-        width: 100%;
-    }
+  .radio-group input[type="radio"] {
+    width: 14px;
+    height: 14px;
+    appearance: none;
+    border: 1px solid #c5c5c5;
+    border-radius: 2px;
+    outline: none;
+    cursor: pointer;
+    position: relative;
+    margin: 4px 5px 0 0;
+  }
 
-    .gpt_reply setting-item > div.width-80 {
-        width: 80% !important;
-    }
+  .radio-group input[type="radio"]:checked {
+    background-color: #008deb;
+    border: 1px solid #008deb;
+  }
 
-    /* Light mode */
-    @media (prefers-color-scheme: light) {
-        .gpt_reply input {
-            color: black;
-        }
-        textarea {
-            color: black;
-        }
-    }
+  .radio-group input[type="radio"]::before {
+    content: "";
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 2px;
+    background-color: white;
+  }
 
-    /* Dark mode */
-    @media (prefers-color-scheme: dark) {
-        .gpt_reply input {
-            color: white;
-        }
-        textarea {
-            color: white;
-        }
-    }
+  .radio-group input[type="radio"]:checked::before {
+    background-color: #008deb;
+  }
 
-    .radio-group {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-    }
+  .radio-group input[type="text"] {
+    display: none;
+    margin-left: 10px;
+    padding: 2px 4px;
+  }
 
-    .radio-group label {
-        margin-right: 15px;
-        display: flex;
-        align-items: center;
-    }
+  .radio-group input[type="radio"]:checked + input[type="text"] {
+    display: inline-block;
+  }
 
-    .radio-group input[type="radio"] {
-        width: 14px;
-        height: 14px;
-        appearance: none;
-        border: 1px solid #c5c5c5;
-        border-radius: 2px;
-        outline: none;
-        cursor: pointer;
-        position: relative;
-        margin: 4px 5px 0 0;
-    }
-
-    .radio-group input[type="radio"]:checked {
-        background-color: #008deb;
-        border: 1px solid #008deb;
-    }
-
-    .radio-group input[type="radio"]::before {
-        content: "";
-        display: block;
-        width: 100%;
-        height: 100%;
-        border-radius: 2px;
-        background-color: white;
-    }
-
-    .radio-group input[type="radio"]:checked::before {
-        background-color: #008deb;
-    }
-
-    .radio-group input[type="text"] {
-        display: none;
-        margin-left: 10px;
-        padding: 2px 4px;
-    }
-
-    .radio-group input[type="radio"]:checked + input[type="text"] {
-        display: inline-block;
-    }
-
-    #system-message {
-        height: 100px;
-        width: 100%;
-    }
+  #system-message {
+    height: 100px;
+    width: 100%;
+  }
 </style>
 
 <setting-section data-title="配置">
-    <setting-panel>
-        <setting-list data-direction="column">
-            <setting-item data-direction="row">
-                <div>
-                    <setting-text>OpenAI API 密钥</setting-text>
-                    <setting-text
-                        data-type="secondary"
-                        style="-webkit-line-clamp: initial"
-                        >填写你自己的 OpenAI API
-                        密钥，或<a
-                            href="javascript:void(0);"
-                            onclick="gpt_reply.openWeb('https://platform.openai.com/docs/quickstart/step-2-set-up-your-api-key')"
-                            >储存成系统变量</a
-                        ></setting-text
-                    >
+  <setting-panel>
+    <setting-list data-direction="column">
+      <setting-item data-direction="row">
+        <div>
+          <setting-text>OpenAI API 密钥</setting-text>
+          <setting-text
+            data-type="secondary"
+            style="-webkit-line-clamp: initial"
+            >填写你自己的 OpenAI API 密钥，或<a
+              href="javascript:void(0);"
+              onclick="gpt_reply.openWeb(`https://platform.openai.com/docs/quickstart/step-2-set-up-your-api-key`)"
+              >储存成系统变量</a
+            >
+          </setting-text>
 
-                    <div class="input-group">
-                        <input
-                            id="openai-api-key"
-                            type="text"
-                            spellcheck="false"
-                            placeholder="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-                        />
-                    </div>
-                </div>
-            </setting-item>
+          <div class="input-group">
+            <input
+              id="openai-api-key"
+              type="text"
+              spellcheck="false"
+              placeholder="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            />
+          </div>
+        </div>
+      </setting-item>
 
-            <setting-item data-direction="row">
-                <div>
-                    <setting-text>自定义 API 接口</setting-text>
-                    <setting-text
-                        data-type="secondary"
-                        style="-webkit-line-clamp: initial"
-                        >支持跳转或使用非官方接口</setting-text>
+      <setting-item data-direction="row">
+        <div>
+          <setting-text>自定义 API 接口</setting-text>
+          <setting-text
+            data-type="secondary"
+            style="-webkit-line-clamp: initial"
+            >支持跳转或使用非官方接口</setting-text
+          >
 
-                    <div class="input-group">
-                        <input
-                            id="openai-base-url"
-                            type="text"
-                            spellcheck="false"
-                            placeholder="https://api.example.com/v2/"
-                        />
-                    </div>
-                </div>
-            </setting-item>
-        </setting-list>
-    </setting-panel>
+          <div class="input-group">
+            <input
+              id="openai-base-url"
+              type="text"
+              spellcheck="false"
+              placeholder="https://api.example.com/v2/"
+            />
+          </div>
+        </div>
+      </setting-item>
+    </setting-list>
+  </setting-panel>
 </setting-section>
 
 <setting-section data-title="模型设置">
-    <setting-panel>
-        <setting-list data-direction="column">
-            <setting-item data-direction="row">
-                <div>
-                    <setting-text>模型号</setting-text>
-                    <setting-text
-                        data-type="secondary"
-                        style="-webkit-line-clamp: initial"
-                        >填写选择模型或填入自定义模型号，如
-                        gpt-4o 查看<a
-                            href="javascript:void(0);"
-                            onclick="gpt_reply.openWeb('https://platform.openai.com/docs/models/models')"
-                            >模型列表</a
-                        ></setting-text
-                    >
+  <setting-panel>
+    <setting-list data-direction="column">
+      <setting-item data-direction="row">
+        <div>
+          <setting-text>模型号</setting-text>
+          <setting-text
+            data-type="secondary"
+            style="-webkit-line-clamp: initial"
+            >填写选择模型或填入自定义模型号，如 gpt-4o 查看<a
+              href="javascript:void(0);"
+              onclick="gpt_reply.openWeb(`https://platform.openai.com/docs/models/models`)"
+              >模型列表</a
+            ><br />duckduckgo暂不支持prompt
+          </setting-text>
 
-                    <div class="radio-group">
-                        <label>
-                            <input
-                                type="radio"
-                                name="chat-model"
-                                value="gpt-4o-mini"
-                                checked
-                            />
-                            GPT-4o mini
-                        </label>
-                        <label>
-                            <input
-                                type="radio"
-                                name="chat-model"
-                                value="gpt-4o"
-                            />
-                            GPT-4o
-                        </label>
-                        <label>
-                            <input
-                                type="radio"
-                                name="chat-model"
-                                value="custom"
-                            />
-                            自定义
-                            <input
-                                id="custom-chat-model"
-                                type="text"
-                                spellcheck="false"
-                                placeholder="输入模型号"
-                            />
-                        </label>
-                    </div>
-                </div>
-            </setting-item>
+          <div class="radio-group">
+            <label>
+              <input
+                type="radio"
+                name="chat-model"
+                value="gpt-4o-mini"
+                checked
+              />
+              GPT-4o mini
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="gpt-4o" />
+              GPT-4o
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="4ominiddg" />
+              4o-mini-ddg
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="llamaddg" />
+              llama3.1-ddg
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="mixtralddg" />
+              mixtral-ddg
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="claudeddg" />
+              claude-haiku-ddg
+            </label>
+            <label>
+              <input type="radio" name="chat-model" value="custom" />
+              自定义
+              <input
+                id="custom-chat-model"
+                type="text"
+                spellcheck="false"
+                placeholder="输入模型号"
+              />
+            </label>
+          </div>
+        </div>
+      </setting-item>
 
-            <!-- <setting-item data-direction="row">
+      <!-- <setting-item data-direction="row">
                 <div>
                     <setting-text>开启模型记忆</setting-text>
                     <setting-text
@@ -242,26 +251,26 @@
                 </div>
             </setting-item> -->
 
-            <setting-item data-direction="row">
-                <div>
-                    <setting-text>系统提示词</setting-text>
-                    <setting-text
-                        data-type="secondary"
-                        style="-webkit-line-clamp: initial"
-                        >在此处定义模型回复的风格</setting-text
-                    >
+      <setting-item data-direction="row">
+        <div>
+          <setting-text>系统提示词</setting-text>
+          <setting-text
+            data-type="secondary"
+            style="-webkit-line-clamp: initial"
+            >在此处定义模型回复的风格</setting-text
+          >
 
-                    <div class="input-group">
-                        <textarea
-                            id="system-message"
-                            spellcheck="false"
-                            placeholder="你在回复群聊消息，请使用以下说话风格&#10;- 你说话言简意赅&#10;- 你喜欢用颜文字卖萌"
-                        ></textarea>
-                    </div>
-                </div>
-            </setting-item>
+          <div class="input-group">
+            <textarea
+              id="system-message"
+              spellcheck="false"
+              placeholder="你在回复群聊消息，请使用以下说话风格&#10;- 你说话言简意赅&#10;- 你喜欢用颜文字卖萌"
+            ></textarea>
+          </div>
+        </div>
+      </setting-item>
 
-            <!-- <setting-item data-direction="row">
+      <!-- <setting-item data-direction="row">
                 <div>
                     <setting-text>回复模式</setting-text>
                     <setting-text
@@ -306,24 +315,24 @@
                     </div>
                 </div>
             </setting-item> -->
-        </setting-list>
-    </setting-panel>
+    </setting-list>
+  </setting-panel>
 </setting-section>
 
 <setting-section data-title="关于">
-    <setting-panel>
-        <setting-list data-direction="column">
-            <setting-item data-direction="row">
-                <div class="width-80">
-                    <setting-text>GitHub 仓库</setting-text>
-                    <setting-text data-type="secondary"
-                        >https://github.com/wangyz1999/LiteLoaderQQNT-GPT-Reply</setting-text
-                    >
-                </div>
-                <setting-button data-type="secondary" id="settings-github-link"
-                    >进去瞅瞅</setting-button
-                >
-            </setting-item>
-        </setting-list>
-    </setting-panel>
+  <setting-panel>
+    <setting-list data-direction="column">
+      <setting-item data-direction="row">
+        <div class="width-80">
+          <setting-text>GitHub 仓库</setting-text>
+          <setting-text data-type="secondary"
+            >https://github.com/wangyz1999/LiteLoaderQQNT-GPT-Reply</setting-text
+          >
+        </div>
+        <setting-button data-type="secondary" id="settings-github-link"
+          >进去瞅瞅</setting-button
+        >
+      </setting-item>
+    </setting-list>
+  </setting-panel>
 </setting-section>


### PR DESCRIPTION
添加对duckduckgo api的支持
- claude3 haiku
- gpt4o-mini
- mixtral
- llama3.1
![image](https://github.com/user-attachments/assets/f6aeccc7-b8dd-4f2c-b777-ce47036ec1e5)
修改文件
- settings.html 添加更多选项，选项较多时自动换行，格式化(我好像忘了添加prettier的配置文件误格式化了😭)。
- package.json 添加了duckduckgo-ai-chat-cjs ，这是由于duckduckgo的api尚未兼容openAI的api规范，使用了仓库 https://github.com/mumu-lhl/duckduckgo-ai-chat 的代码并加以修改。
- main.js 添加了处理duckduckgo api的逻辑，包括普通处理和流式处理
- render.js 修正了存储settings.json的逻辑，使得再更多的选项添加时可以正常在qq启动时切换到保存选项。
- .gitignore 添加了一些gitignore文件

解决issue #12 
其中OpenRouter和DeepSeek已经兼容OpenAI的API。